### PR TITLE
Add English keys to `en/battle.json`

### DIFF
--- a/en/battle.json
+++ b/en/battle.json
@@ -62,6 +62,8 @@
   "noPokeballMulti": "You can only throw a Poké Ball\nwhen there is one Pokémon remaining!",
   "noPokeballStrong": "The target Pokémon is too strong to be caught!\nYou need to weaken it first!",
   "noPokeballMysteryEncounter": "You aren't able to\ncatch this Pokémon!",
+  "noPokeballTarget": "There is no Pokémon to capture!",
+  "noPokeballSemiInvulnerable": "You can't catch a hidden Pokémon!",
   "noEscapeForce": "An unseen force\nprevents escape.",
   "noEscapeTrainer": "You can't run\nfrom a trainer battle!",
   "noEscapePokemon": "{{pokemonName}}'s {{moveName}}\nprevents {{escapeVerb}}!",


### PR DESCRIPTION
`noPokeballTarget` and `noPokeballSemiInvulnerable`, used when the player can't throw a pokeball because there is no target somehow or the target is semi-invulnerable (ie: due to Fly/etc)

Added in https://github.com/Despair-Games/poketernity/pull/22