### PR TITLE
Add `settings:saveAndClose` & `settings:orientation`

### DIFF
--- a/en/settings.json
+++ b/en/settings.json
@@ -113,5 +113,6 @@
   "defaultConfirmMessage": "Are you sure?",
   "landscape": "Landscape",
   "portrait": "Portrait",
-  "configure": "Configure"
+  "configure": "Configure",
+  "saveAndClose": "Save & Close"
 }

--- a/en/settings.json
+++ b/en/settings.json
@@ -114,5 +114,6 @@
   "landscape": "Landscape",
   "portrait": "Portrait",
   "configure": "Configure",
-  "saveAndClose": "Save & Close"
+  "saveAndClose": "Save & Close",
+  "orientation": "Orientation"
 }


### PR DESCRIPTION
Necessary for https://github.com/Despair-Games/poketernity/pull/50

Used in the configuration overlay of the touch controls:

<img width="409" alt="image" src="https://github.com/user-attachments/assets/d32470ae-e10a-4360-8f55-abf763bc651f" />
