### PR TITLE
[Localization] New Key for 'Can't release Pokemon'

### DIFF
--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -46,5 +46,6 @@
   "illNeverForgetYou": "I'll never forget you, {{pokemonName}}!",
   "untilWeMeetAgain": "Until we meet again, {{pokemonName}}!",
   "sayonara": "Sayonara, {{pokemonName}}!",
-  "smellYaLater": "Smell ya later, {{pokemonName}}!"
+  "smellYaLater": "Smell ya later, {{pokemonName}}!",
+  "cannotReleasePokemon": "You can't release your only usable Pokemon!"
 }

--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -46,5 +46,6 @@
   "illNeverForgetYou": "I'll never forget you, {{pokemonName}}!",
   "untilWeMeetAgain": "Until we meet again, {{pokemonName}}!",
   "sayonara": "Sayonara, {{pokemonName}}!",
-  "cannotReleasePokemon": "You can't release your only usable Pokemon!"
+  "cannotReleasePokemon": "You can't release your only usable Pokemon!",
+  "smellYaLater": "Smell ya later, {{pokemonName}}!"
 }

--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -46,6 +46,5 @@
   "illNeverForgetYou": "I'll never forget you, {{pokemonName}}!",
   "untilWeMeetAgain": "Until we meet again, {{pokemonName}}!",
   "sayonara": "Sayonara, {{pokemonName}}!",
-  "smellYaLater": "Smell ya later, {{pokemonName}}!",
   "cannotReleasePokemon": "You can't release your only usable Pokemon!"
 }


### PR DESCRIPTION
During a challenge run, players can release their only eligible Pokemon and end up softlocking their run. This message is used to notify the player that they cannot release their Pokemon.

PR Link: TBD