### PR TITLE
[Ability][EN] Edited Forewarn's English key to include name of opponent

### DIFF
--- a/en/ability-trigger.json
+++ b/en/ability-trigger.json
@@ -35,7 +35,7 @@
   "statusEffectImmunity": "{{pokemonNameWithAffix}}'s {{abilityName}}\nprevents status problems!",
   "battlerTagImmunity": "{{pokemonNameWithAffix}}'s {{abilityName}}\nprevents {{battlerTagName}}!",
   "typeImmunityPowerBoost": "The power of {{pokemonNameWithAffix}}'s {{typeName}}-type moves rose!",
-  "forewarn": "{{pokemonNameWithAffix}} was forewarned about {{moveName}}!",
+  "forewarn": "{{pokemonNameWithAffix}} was forewarned about {{opponentNameWithAffix}}'s {{moveName}}!",
   "frisk": "{{pokemonNameWithAffix}} frisked {{opponentName}}'s {{opponentAbilityName}}!",
   "postWeatherLapseHeal": "{{pokemonNameWithAffix}}'s {{abilityName}}\nrestored its HP a little!",
   "postWeatherLapseDamage": "{{pokemonNameWithAffix}} is hurt\nby its {{abilityName}}!",

--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -46,5 +46,6 @@
   "illNeverForgetYou": "I'll never forget you, {{pokemonName}}!",
   "untilWeMeetAgain": "Until we meet again, {{pokemonName}}!",
   "sayonara": "Sayonara, {{pokemonName}}!",
-  "smellYaLater": "Smell ya later, {{pokemonName}}!"
+  "smellYaLater": "Smell ya later, {{pokemonName}}!",
+  "cannotReleasePokemon": "You can't release your only usable Pokemon!"
 }

--- a/en/party-ui-handler.json
+++ b/en/party-ui-handler.json
@@ -46,6 +46,5 @@
   "illNeverForgetYou": "I'll never forget you, {{pokemonName}}!",
   "untilWeMeetAgain": "Until we meet again, {{pokemonName}}!",
   "sayonara": "Sayonara, {{pokemonName}}!",
-  "smellYaLater": "Smell ya later, {{pokemonName}}!",
   "cannotReleasePokemon": "You can't release your only usable Pokemon!"
 }


### PR DESCRIPTION
This will update Forewarn to match mainline / Smogon. It will also let the player know which Pokemon has the strongest BP move. Previously, the key was "{{pokemonNameWithAffix}} was forewarned about {{moveName}}!", not "{{pokemonNameWithAffix}} was forewarned about {{opponentName}}'s {{moveName}}!"
![image](https://github.com/user-attachments/assets/20fad381-147d-49e8-9105-2de6a88d006d)
