### PR TITLE
[EN] Add messages for Splash, Celebrate, and Hold Hands

### DIFF
--- a/en/move-trigger.json
+++ b/en/move-trigger.json
@@ -78,5 +78,8 @@
   "instructingMove": "{{targetPokemonName}} followed {{userPokemonName}}’s instructions!",
   "lunarDanceRestore" : "{{pokemonName}} became cloaked in mystical moonlight!",
   "stealPositiveStats": "{{pokemonname}} stole the target’s boosted stats!",
-  "rageIsBuilding": "{{pokemonName}}'s rage is building!"
+  "rageIsBuilding": "{{pokemonName}}'s rage is building!",
+  "splash": "But nothing happened!",
+  "celebrate": "Congratulations {{pokemonName}}!",
+  "holdHands": "{{pokemonName held hands with {{targetPokemonName}}!"
 }

--- a/en/move-trigger.json
+++ b/en/move-trigger.json
@@ -81,5 +81,5 @@
   "rageIsBuilding": "{{pokemonName}}'s rage is building!",
   "splash": "But nothing happened!",
   "celebrate": "Congratulations {{pokemonName}}!",
-  "holdHands": "{{pokemonName held hands with {{targetPokemonName}}!"
+  "holdHands": "{{pokemonName}} held hands with {{targetPokemonName}}!"
 }


### PR DESCRIPTION
* Splash ref: https://bulbapedia.bulbagarden.net/wiki/Splash_(move)
* Celebrate ref: https://bulbapedia.bulbagarden.net/wiki/Celebrate_(move)
* Hold hands ref: https://www.youtube.com/watch?v=XSkVIqd7J3Y

Custom implementations:
* Celebrate displays `Congratulations {{pokemonName}}!` instead of `Congratulations {{player}}!"
* Hold hands does not display any message in game so I created a custom message