### PR TITLE
Create PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,30 +1,30 @@
 ## What are the changes introduced by this PR
 
-<!-- Tell what this PR does and why. -->
-<!-- Specifies which keys are being created, added or removed, if any-->
+<!-- Tell what this PR does and why -->
+<!-- Specify which keys are being created, added or removed, if any -->
 
 ## Checklist
-
+<!-- This section can be ignored if the PR only adds translations to existing key(s) or fixes typo(s) -->
 - [ ] Have I created an associated PR in the main repo?
   - [ ] Please link it here:
-- [ ] Have made sure that the changes work in game?
-  - [ ] Have I included screenshots of them in this PR, or the main repo PR?
+- [ ] Have I made sure that the changes work in game?
+  - [ ] Have I provided screenshots of it in this PR or the main repo PR?
 
-- [ ] Does this PR adds new key(s) to localize?
-  - [ ] If so, have I added the new key(s) only in the English file(s)
-<!-- not relevant for now - [ ] Has the translation/proofreading team has been contacted? -->
-<details><summary>Merging process reminder</summary>
+#### Does this PR add new key(s) to localize?
+- [ ] If so, have I made sure to add the new key(s) in the English file(s) only?
+<!-- not relevant for now - [ ] Has the translation/proofreading team been contacted about the new key(s)? -->
+<details><summary>Merging process reminder for this situation</summary>
 
-- **If the PR also updates or removes key(s), please refer to the process reminder for these cases instead**
-- This locale PR can be merged at any time as long as it has been approved
+- **If the PR also updates or removes key(s), please refer below to the process for these cases instead**
+- If not, this locale PR can be merged at any time as long as it has been approved
 - The main PR can then update the submodule by running the command `git submodule update --remote --recursive --force` and committing the change
 
 </details>
 
-- [ ] Does this PR updates or removes existing key(s)
-  - [ ] If so, I have deleted the outdated key(s) in all languages other than English
-<!-- not relevant for now - [ ] Has the translation/proofreading team has been contacted about the updated key(s)? -->
-<details><summary>Merging process reminder</summary>
+#### Does this PR update or remove existing key(s) in English?
+- [ ] If so, have I deleted the outdated key(s) in all languages other than English?
+<!-- not relevant for now - [ ] Has the translation/proofreading team been contacted about the updated key(s)? -->
+<details><summary>Merging process reminder for this situation</summary>
 
 - This locale PR should **not** be merged until the main repo PR is ready to be merged itself
 - Once both the main repo PR and this PR have the needeed approvals:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+## What are the changes introduced by this PR
+
+<!-- Tell what this PR does and why. -->
+<!-- Specifies which keys are being created, added or removed, if any-->
+
+## Checklist
+
+- [ ] Have I created an associated PR in the main repo?
+  - [ ] Please link it here:
+- [ ] Have made sure that the changes work in game?
+  - [ ] Have I included screenshots of them in this PR, or the main repo PR?
+
+- [ ] Does this PR adds new key(s) to localize?
+  - [ ] If so, have I added the new key(s) only in the English file(s)
+<!-- not relevant for now - [ ] Has the translation/proofreading team has been contacted? -->
+<details><summary>Merging process reminder</summary>
+
+- **If the PR also updates or removes key(s), please refer to the process reminder for these cases instead**
+- This locale PR can be merged at any time as long as it has been approved
+- The main PR can then update the submodule by running the command `git submodule update --remote --recursive --force` and committing the change
+
+</details>
+
+- [ ] Does this PR updates or removes existing key(s)
+  - [ ] If so, I have deleted the outdated key(s) in all languages other than English
+<!-- not relevant for now - [ ] Has the translation/proofreading team has been contacted about the updated key(s)? -->
+<details><summary>Merging process reminder</summary>
+
+- This locale PR should **not** be merged until the main repo PR is ready to be merged itself
+- Once both the main repo PR and this PR have the needeed approvals:
+  - Merge this locale PR
+  - In the main PR, update the submodule by running the command `git submodule update --remote --recursive --force` and committing the change
+  - The main repo PR can now be merged
+
+</details>


### PR DESCRIPTION
This adds a PR template to the repo to help remind devs of the steps required when adding, updating or removing keys and of the merging process in each case. The merging process reminders get added to the PR description itself (in dropdowns) so that anyone looking at merging/approving the PR can consult them if needed as well.

Feel free to suggest modifications/additions.
<br/>

Here is how a PR created with the template would look like after it's been posted:
(I have added all the `<!-- comments -->` in code blocks so that you can read them from here)


## What are the changes introduced by this PR

`<!-- Tell what this PR does and why -->`
`<!-- Specify which keys are being created, added or removed, if any -->`

## Checklist
`<!-- This section can be ignored if the PR only adds translations to existing key(s) or fixes typo(s) -->`
- [ ] Have I created an associated PR in the main repo?
  - [ ] Please link it here:
- [ ] Have I made sure that the changes work in game?
  - [ ] Have I provided screenshots of it in this PR or the main repo PR?

#### Does this PR add new key(s) to localize?
- [ ] If so, have I made sure to add the new key(s) in the English file(s) only?
`<!-- not relevant for now - [ ] Has the translation/proofreading team been contacted about the new key(s)? -->`
<details><summary>Merging process reminder for this situation</summary>

- **If the PR also updates or removes key(s), please refer below to the process for these cases instead**
- If not, this locale PR can be merged at any time as long as it has been approved
- The main PR can then update the submodule by running the command `git submodule update --remote --recursive --force` and committing the change

</details>

#### Does this PR update or remove existing key(s) in English?
- [ ] If so, have I deleted the outdated key(s) in all languages other than English?
`<!-- not relevant for now - [ ] Has the translation/proofreading team been contacted about the updated key(s)? -->`
<details><summary>Merging process reminder for this situation</summary>

- This locale PR should **not** be merged until the main repo PR is ready to be merged itself
- Once both the main repo PR and this PR have the needeed approvals:
  - Merge this locale PR
  - In the main PR, update the submodule by running the command `git submodule update --remote --recursive --force` and committing the change
  - The main repo PR can now be merged

</details>
