### PR TITLE
[EN] Fix incorrect usage of `pokemonName` in Uproar's header message

### DIFF
--- a/en/move-trigger.json
+++ b/en/move-trigger.json
@@ -82,5 +82,5 @@
   "splash": "But nothing happened!",
   "celebrate": "Congratulations {{pokemonName}}!",
   "holdHands": "{{pokemonName}} held hands with {{targetPokemonName}}!",
-  "isMakingAnUproar": "{{pokemonName}} is making an uproar!"
+  "isMakingAnUproar": "{{pokemonNameWithAffix}} is making an uproar!"
 }


### PR DESCRIPTION
## What are the changes introduced by this PR?

Uproar's header message now uses `{{pokemonNameWithAffix}}` instead of `{{pokemonName}}` to be more accurate to how the message is generated.

## Checklist
<!-- This section can be ignored if the PR only adds translations to existing key(s) or fixes typo(s) -->
- [x] Have I created an associated PR in the main repo?
  - [x] Please link it here: https://github.com/Despair-Games/poketernity/pull/699
- [ ] Have I made sure that the changes work in game?
  - [ ] Have I provided screenshots of it in this PR or the main repo PR?

#### Does this PR update or remove existing key(s) in English?
- [n/a] If so, have I deleted the outdated key(s) in all languages other than English?
<!-- not relevant for now - [ ] Has the translation/proofreading team been contacted about the updated key(s)? -->
<details><summary>Merging process reminder for this situation</summary>

- This locale PR should **not** be merged until the main repo PR is ready to be merged itself
- Once both the main repo PR and this PR have the needeed approvals:
  - Merge this locale PR
  - In the main PR, update the submodule by running the command `npm run update-locales:remote` and committing the change
  - The main repo PR can now be merged

</details>
